### PR TITLE
ci: drop node 10 and 12 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fastify v4.x dropped support for EOL versions of node like 10 and 12, so testing against them will cause errors.

Also added 16 and 18.